### PR TITLE
GameObject of Type Attribute

### DIFF
--- a/Assets/VavilichevGD/Utils/Attributes.meta
+++ b/Assets/VavilichevGD/Utils/Attributes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bf4430e76ace46140907c88fb5e4c327
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VavilichevGD/Utils/Attributes/GameObjectOfType.meta
+++ b/Assets/VavilichevGD/Utils/Attributes/GameObjectOfType.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 491251cc36852ce488aa2da67607a4a7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VavilichevGD/Utils/Attributes/GameObjectOfType/GameObjectOfTypeAttribute.cs
+++ b/Assets/VavilichevGD/Utils/Attributes/GameObjectOfType/GameObjectOfTypeAttribute.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using UnityEngine;
+
+namespace VavilichevGD.Utils.Attributes.GameObjectOfType {
+    public class GameObjectOfTypeAttribute : PropertyAttribute {
+        public Type type { get; }
+ 
+        public GameObjectOfTypeAttribute(Type type)
+        {
+            this.type = type;
+        }
+    }
+}

--- a/Assets/VavilichevGD/Utils/Attributes/GameObjectOfType/GameObjectOfTypeAttribute.cs.meta
+++ b/Assets/VavilichevGD/Utils/Attributes/GameObjectOfType/GameObjectOfTypeAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3d68e42b44ba4bd4782a5d2c08aaab23
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VavilichevGD/Utils/Attributes/GameObjectOfType/GameObjectOfTypeDrawer.cs
+++ b/Assets/VavilichevGD/Utils/Attributes/GameObjectOfType/GameObjectOfTypeDrawer.cs
@@ -1,0 +1,48 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace VavilichevGD.Utils.Attributes.GameObjectOfType {
+	[CustomPropertyDrawer(typeof(GameObjectOfTypeAttribute))]
+	public class GameObjectOfTypeDrawer : PropertyDrawer {
+		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
+
+			// Show error if property type is not a reference or source object is not a game object
+			if (property.propertyType != SerializedPropertyType.ObjectReference || !property.type.Contains($"{nameof(GameObject)}")) {
+				DrawErrorOfType(position);
+				return;
+			}
+			
+			var gootAttribute = attribute as GameObjectOfTypeAttribute;
+
+			// Handle the dragging objects
+			var draggedObjectsCount = DragAndDrop.objectReferences.Length;
+			if (draggedObjectsCount > 0) {
+				
+				for (int i = 0; i < draggedObjectsCount; i++) {
+					var draggedObject = DragAndDrop.objectReferences[i] as GameObject;
+					
+					if (draggedObject == null || (draggedObject != null && draggedObject.GetComponent(gootAttribute.type) == null)) {
+						DragAndDrop.visualMode = DragAndDropVisualMode.Rejected;
+					}
+				}
+			}
+
+			// If wrong type was putted into the property field it should be cleaned
+			if (property.objectReferenceValue != null) {
+				var go = property.objectReferenceValue as GameObject;
+				
+				if (go != null && go.GetComponent(gootAttribute.type) == null) {
+					property.objectReferenceValue = null;
+				}
+			}
+
+			var modifiedLabel = $"{label.text} ({gootAttribute.type.Name})";
+			property.objectReferenceValue = EditorGUI.ObjectField(position, modifiedLabel, property.objectReferenceValue, typeof(GameObject), true);
+		}
+		
+		private void DrawErrorOfType(Rect position)
+		{
+			EditorGUI.HelpBox(position, $"{nameof(GameObjectOfTypeAttribute)} works only with {nameof(GameObject)} type", MessageType.Error);
+		}
+	}
+}

--- a/Assets/VavilichevGD/Utils/Attributes/GameObjectOfType/GameObjectOfTypeDrawer.cs.meta
+++ b/Assets/VavilichevGD/Utils/Attributes/GameObjectOfType/GameObjectOfTypeDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: de475cc1d137b5b4797effd92464cfb9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
You can use this attribute for showing in the editor for specifically game objects that have component of different types such as interfaces or abstract classes.